### PR TITLE
fix: linux CI tests 

### DIFF
--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -11,7 +11,8 @@ Library for automating workflows and testing NEAR smart contracts.
 
 [dependencies]
 async-trait = "0.1"
-async-process = "=1.7.0"
+# The version is pinned to <=1.7.0 because of the following issue: https://github.com/near/near-workspaces-rs/issues/312
+async-process = "<=1.7.0"
 base64 = "0.21"
 borsh = "0.10"
 bs58 = "0.5"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -11,7 +11,7 @@ Library for automating workflows and testing NEAR smart contracts.
 
 [dependencies]
 async-trait = "0.1"
-# The version is pinned to <=1.7.0 because of the following issue: https://github.com/near/near-workspaces-rs/issues/312
+# The version is pinned to <=1.7.0 because of the following issue: https://github.com/smol-rs/async-process/issues/55
 async-process = "<=1.7.0"
 base64 = "0.21"
 borsh = "0.10"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -11,11 +11,11 @@ Library for automating workflows and testing NEAR smart contracts.
 
 [dependencies]
 async-trait = "0.1"
-async-process = "1.3"
+async-process = "=1.7.0"
 base64 = "0.21"
 borsh = "0.10"
 bs58 = "0.5"
-cargo_metadata = { version = "0.17", optional = true }
+cargo_metadata = { version = "0.18", optional = true }
 cargo-near = "0.3.1"
 chrono = "0.4.19"
 fs2 = "0.4"
@@ -39,10 +39,10 @@ near-crypto = "0.17"
 near-primitives = "0.17"
 near-jsonrpc-primitives = "0.17"
 near-jsonrpc-client = { version = "0.6", features = ["sandbox"] }
-near-sandbox-utils = "0.6.2"
+near-sandbox-utils = { git = "https://github.com/shariffdev/sandbox.git", branch = "fix/pin-async-process-ver" }
 near-chain-configs = { version = "0.17.0", optional = true }
 [build-dependencies]
-near-sandbox-utils = "0.6.2"
+near-sandbox-utils = { git = "https://github.com/shariffdev/sandbox.git", branch = "fix/pin-async-process-ver" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
Closes: https://github.com/near/near-workspaces-rs/issues/312
Associated PR: https://github.com/near/sandbox/pull/66

The PR pins `async-process`  to version `1.7.0` that was used before the Linux test issue started. 
`near-sandbox` was the outlier, used`async-process ^1` that automatically made the update.

`async-process` Issue: https://github.com/smol-rs/async-process/issues/55 