### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.8.0...near-workspaces-v0.9.0) - 2023-10-06
+
+### Added
+- Added API for measuring gas ([#284](https://github.com/near/near-workspaces-rs/pull/284))
+
+### Other
+- remove unwraps ([#321](https://github.com/near/near-workspaces-rs/pull/321))
+
 ## [0.8.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.7.0...near-workspaces-v0.8.0) - 2023-10-04
 
 - [**breaking**] renamed crate to near-workspaces to avoid confusion with Cargo workspaces; imports should now use `near_workspaces` instead of just `workspaces` ([#318](https://github.com/near/near-workspaces-rs/pull/318))

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/workspaces/src/types/gas_meter.rs
+++ b/workspaces/src/types/gas_meter.rs
@@ -1,3 +1,4 @@
+use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::sync::{Arc, Mutex};
 
 use super::Gas;
@@ -7,7 +8,11 @@ use crate::Worker;
 /// A hook that is called on every transaction that is sent to the network.
 /// This is useful for debugging purposes, or for tracking the amount of gas
 /// that is being used.
-pub type GasHook = Arc<dyn Fn(Gas) -> Result<()> + Send + Sync>;
+///
+/// The auto-traits [`Send`], [`Sync`], [`UnwindSafe`] and [`RefUnwindSafe`] are added explicitly because they
+/// do not fall under the rules the compiler uses to automatically add them.
+/// See here: <https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits>
+pub type GasHook = Arc<dyn Fn(Gas) -> Result<()> + Send + Sync + UnwindSafe + RefUnwindSafe>;
 
 /// Allows you to meter the amount of gas consumed by transaction(s).
 /// Note: This only works with transactions that resolve to [`crate::result::ExecutionFinalResult`]


### PR DESCRIPTION
## 🤖 New release
* `near-workspaces`: 0.8.0 -> 0.9.0 (⚠️ API breaking changes)

### ⚠️ `near-workspaces` breaking changes

```
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.23.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type Worker is no longer RefUnwindSafe, in /tmp/.tmpy0o2j8/near-workspaces-rs/workspaces/src/worker/mod.rs:15
  type Worker is no longer UnwindSafe, in /tmp/.tmpy0o2j8/near-workspaces-rs/workspaces/src/worker/mod.rs:15
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.8.0...near-workspaces-v0.9.0) - 2023-10-06

### Added
- Added API for measuring gas ([#284](https://github.com/near/near-workspaces-rs/pull/284))

### Other
- remove unwraps ([#321](https://github.com/near/near-workspaces-rs/pull/321))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).