### PR TITLE
fix: Fixed await during acquired lock in rpc::client::fetch_tx_nonce

### DIFF
--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -3,6 +3,9 @@
 //! A library for automating workflows and writing tests for NEAR smart contracts.
 //! This software is not final, and will likely change.
 
+// We want to enable all clippy lints, but some of them generate false positives.
+#![allow(clippy::missing_const_for_fn, clippy::redundant_pub_crate)]
+
 #[cfg(feature = "unstable")]
 mod cargo;
 #[cfg(feature = "unstable")]


### PR DESCRIPTION
This was flagged by clippy with `nursery` lints enabled:

```
cargo clippy --all-features --workspace -- --warn clippy::all --warn clippy::nursery
```

(There are more warnings to address in #328)