### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.9.0...near-workspaces-v0.10.0) - 2024-01-25
+
+### Other
+- Impl Clone on result Value ([#345](https://github.com/near/near-workspaces-rs/pull/345))
+- Upgraded NEAR crates to 0.20.0 release ([#346](https://github.com/near/near-workspaces-rs/pull/346))
+- dependecy bumps ([#338](https://github.com/near/near-workspaces-rs/pull/338))
+- cleanup internals ([#329](https://github.com/near/near-workspaces-rs/pull/329))
+- use stable sandbox by default ([#335](https://github.com/near/near-workspaces-rs/pull/335))
+- [**breaking**] Remove `interop_sdk` feature from defaults ([#339](https://github.com/near/near-workspaces-rs/pull/339))
+- fix typos ([#340](https://github.com/near/near-workspaces-rs/pull/340))
+
 ## [0.9.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.8.0...near-workspaces-v0.9.0) - 2023-10-30
 
 ### Added

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `near-workspaces`: 0.9.0 -> 0.10.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.9.0...near-workspaces-v0.10.0) - 2024-01-25

### Other
- Impl Clone on result Value ([#345](https://github.com/near/near-workspaces-rs/pull/345))
- Upgraded NEAR crates to 0.20.0 release ([#346](https://github.com/near/near-workspaces-rs/pull/346))
- dependecy bumps ([#338](https://github.com/near/near-workspaces-rs/pull/338))
- cleanup internals ([#329](https://github.com/near/near-workspaces-rs/pull/329))
- use stable sandbox by default ([#335](https://github.com/near/near-workspaces-rs/pull/335))
- [**breaking**] Remove `interop_sdk` feature from defaults ([#339](https://github.com/near/near-workspaces-rs/pull/339))
- fix typos ([#340](https://github.com/near/near-workspaces-rs/pull/340))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).