### PR TITLE
fix: add clone to result value

### DIFF
--- a/workspaces/src/result.rs
+++ b/workspaces/src/result.rs
@@ -2,18 +2,21 @@
 
 use std::fmt;
 
+use base64::{engine::general_purpose, Engine as _};
 use near_account_id::AccountId;
 use near_gas::NearGas;
-use near_primitives::errors::TxExecutionError;
-use near_primitives::views::{
-    CallResult, ExecutionOutcomeWithIdView, ExecutionStatusView, FinalExecutionOutcomeView,
-    FinalExecutionStatus,
+use near_primitives::{
+    errors::TxExecutionError,
+    views::{
+        CallResult, ExecutionOutcomeWithIdView, ExecutionStatusView, FinalExecutionOutcomeView,
+        FinalExecutionStatus,
+    },
 };
 
-use crate::error::ErrorKind;
-use crate::types::{CryptoHash, Gas, NearToken};
-
-use base64::{engine::general_purpose, Engine as _};
+use crate::{
+    error::ErrorKind,
+    types::{CryptoHash, Gas, NearToken},
+};
 
 pub type Result<T, E = crate::error::Error> = core::result::Result<T, E>;
 
@@ -482,7 +485,7 @@ pub enum ValueOrReceiptId {
 /// Value type returned from an [`ExecutionOutcome`] or receipt result. This value
 /// can be converted into the underlying Rust datatype, or directly grab the raw
 /// bytes associated to the value.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Value {
     repr: String,
 }


### PR DESCRIPTION
In my tests I need to clone: `pub type ExecutionSuccess = ExecutionResult<Value>;`
`ExecutionResult` itself is clonable but `Value` is not so I think it should be clonable too.

I guess the tests should pass after this PR: https://github.com/near/near-workspaces-rs/pull/343?