### PR TITLE
feat: create dev account with deposit on sandbox

### DIFF
--- a/workspaces/src/network/testnet.rs
+++ b/workspaces/src/network/testnet.rs
@@ -1,19 +1,20 @@
-use std::path::PathBuf;
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
 use async_trait::async_trait;
 use near_gas::NearGas;
+use near_primitives::views::ExecutionStatusView;
 use url::Url;
 
-use near_primitives::views::ExecutionStatusView;
-
-use crate::network::builder::{FromNetworkBuilder, NetworkBuilder};
-use crate::network::Info;
-use crate::network::{AllowDevAccountCreation, NetworkClient, NetworkInfo, TopLevelAccountCreator};
-use crate::result::{Execution, ExecutionDetails, ExecutionFinalResult, ExecutionOutcome, Result};
-use crate::rpc::{client::Client, tool};
-use crate::types::{AccountId, InMemorySigner, NearToken, SecretKey};
-use crate::{Account, Contract, CryptoHash, Network, Worker};
+use crate::{
+    network::{
+        builder::{FromNetworkBuilder, NetworkBuilder},
+        AllowDevAccountCreation, Info, NetworkClient, NetworkInfo, TopLevelAccountCreator,
+    },
+    result::{Execution, ExecutionDetails, ExecutionFinalResult, ExecutionOutcome, Result},
+    rpc::{client::Client, tool},
+    types::{AccountId, InMemorySigner, NearToken, SecretKey},
+    Account, Contract, CryptoHash, Network, Worker,
+};
 
 /// URL to the testnet RPC node provided by near.org.
 pub const RPC_URL: &str = "https://rpc.testnet.near.org";
@@ -120,6 +121,16 @@ impl TopLevelAccountCreator for Testnet {
             result: Contract::account(account.into_result()?),
             details: ExecutionFinalResult::from_view(outcome),
         })
+    }
+
+    async fn create_tla_with_deposit(
+        &self,
+        _worker: Worker<dyn Network>,
+        _id: AccountId,
+        _sk: SecretKey,
+        _deposit: NearToken,
+    ) -> Result<Execution<Account>> {
+        unimplemented!("Creating accounts with deposit is not supported on Testnet")
     }
 }
 

--- a/workspaces/tests/account.rs
+++ b/workspaces/tests/account.rs
@@ -94,3 +94,16 @@ async fn test_delete_account() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test(tokio::test)]
+async fn test_dev_account_with_deposit() -> anyhow::Result<()> {
+    let worker = near_workspaces::sandbox().await?;
+
+    let amount = NearToken::from_near(1_111_222);
+
+    let account = worker.dev_create_account_with_deposit(amount).await?;
+
+    assert_eq!(amount, account.view_account().await?.balance);
+
+    Ok(())
+}


### PR DESCRIPTION
In my tests I needed to have an account with big amount of Near to test big chunks of data and pay for storage. 
I couldn't find a way to create account with more Near than hardcoded by default so I added a new method: `dev_create_account_with_deposit`.