### PR TITLE
docs: a way to get account with more than 100 near on sandbox

### DIFF
--- a/workspaces/src/network/variants.rs
+++ b/workspaces/src/network/variants.rs
@@ -78,6 +78,18 @@ where
         (id, sk)
     }
 
+    /// Creates a top level developement account.
+    /// On sandbox network it has a balance of 100 Near.
+    /// If you need more Near for your tests in sandbox consider using `root_account()` method:
+    ///
+    /// # Examples
+    /// ```
+    /// use near_workspaces::{result::Result, Account, network::Sandbox, Worker};
+    /// fn get_account_with_lots_of_near(worker: &Worker<Sandbox>) -> Result<Account> {
+    ///     worker.root_account()
+    /// }
+    /// ```
+    ///
     pub async fn dev_create_account(&self) -> Result<Account> {
         let (id, sk) = self.dev_generate().await;
         let account = self.create_tla(id.clone(), sk).await?;


### PR DESCRIPTION
This issue: https://github.com/near/near-workspaces-rs/issues/156 and my PR: https://github.com/near/near-workspaces-rs/pull/350 indicate that it is not clear for users how to create a dev account with more than 100 Near.

Closes: https://github.com/near/near-workspaces-rs/issues/156