### PR TITLE
Testnet: error handling and add .testnet to dev_generate

### DIFF
--- a/workspaces/src/network/testnet.rs
+++ b/workspaces/src/network/testnet.rs
@@ -7,6 +7,7 @@ use url::Url;
 
 use near_primitives::views::ExecutionStatusView;
 
+use crate::error::ErrorKind;
 use crate::network::builder::{FromNetworkBuilder, NetworkBuilder};
 use crate::network::Info;
 use crate::network::{AllowDevAccountCreation, NetworkClient, NetworkInfo, TopLevelAccountCreator};
@@ -75,6 +76,11 @@ impl TopLevelAccountCreator for Testnet {
         sk: SecretKey,
         // TODO: return Account only, but then you don't get metadata info for it...
     ) -> Result<Execution<Account>> {
+        let mut id = id;
+        if self.info().name.eq("testnet") {
+            id = AccountId::from_str(format!("{}.testnet", id.as_str()).as_str()).
+            map_err(|err| ErrorKind::DataConversion.custom(err))?;
+        }
         let url = Url::parse(HELPER_URL).unwrap();
         tool::url_create_account(url, id.clone(), sk.public_key()).await?;
         let signer = InMemorySigner::from_secret_key(id, sk);

--- a/workspaces/src/network/testnet.rs
+++ b/workspaces/src/network/testnet.rs
@@ -78,8 +78,8 @@ impl TopLevelAccountCreator for Testnet {
     ) -> Result<Execution<Account>> {
         let mut id = id;
         if self.info().name.eq("testnet") {
-            id = AccountId::from_str(format!("{}.testnet", id.as_str()).as_str()).
-            map_err(|err| ErrorKind::DataConversion.custom(err))?;
+            id = AccountId::from_str(format!("{}.testnet", id.as_str()).as_str())
+                .map_err(|err| ErrorKind::DataConversion.custom(err))?;
         }
         let url = Url::parse(HELPER_URL).unwrap();
         tool::url_create_account(url, id.clone(), sk.public_key()).await?;

--- a/workspaces/src/network/variants.rs
+++ b/workspaces/src/network/variants.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::network::Info;
 use crate::result::{Execution, Result};
 use crate::rpc::client::Client;
@@ -75,6 +77,11 @@ where
     pub async fn dev_generate(&self) -> (AccountId, SecretKey) {
         let id = crate::rpc::tool::random_account_id();
         let sk = SecretKey::from_seed(KeyType::ED25519, DEV_ACCOUNT_SEED);
+        if self.info().name.eq("testnet") {
+            let id: AccountId = AccountId::from_str(format!("{}.testnet", id.as_str()).as_str())
+                .expect("could not convert string account id into AccountId");
+            return (id, sk);
+        }
         (id, sk)
     }
 

--- a/workspaces/src/network/variants.rs
+++ b/workspaces/src/network/variants.rs
@@ -77,11 +77,6 @@ where
     pub async fn dev_generate(&self) -> (AccountId, SecretKey) {
         let id = crate::rpc::tool::random_account_id();
         let sk = SecretKey::from_seed(KeyType::ED25519, DEV_ACCOUNT_SEED);
-        if self.info().name.eq("testnet") {
-            let id: AccountId = AccountId::from_str(format!("{}.testnet", id.as_str()).as_str())
-                .expect("could not convert string account id into AccountId");
-            return (id, sk);
-        }
         (id, sk)
     }
 

--- a/workspaces/src/network/variants.rs
+++ b/workspaces/src/network/variants.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use crate::network::Info;
 use crate::result::{Execution, Result};
 use crate::rpc::client::Client;

--- a/workspaces/src/rpc/tool.rs
+++ b/workspaces/src/rpc/tool.rs
@@ -81,9 +81,9 @@ pub(crate) async fn url_create_account(
         near_primitives::views::FinalExecutionStatus::Failure(err) => {
             return Err(ErrorKind::Execution.custom(err));
         }
-        _ => unreachable!()
+        _ => unreachable!(),
     }
-    
+
     Ok(())
 }
 

--- a/workspaces/tests/account.rs
+++ b/workspaces/tests/account.rs
@@ -26,7 +26,7 @@ async fn test_dev_account_creation() -> anyhow::Result<()> {
     let id = AccountId::from_str(format!("{}.testnet", id.as_str()).as_str())?;
     let err = worker.create_tla(id, sk).await;
     assert!(err.is_err_and(|e| e.kind() == &ErrorKind::Execution));
-  
+
     Ok(())
 }
 


### PR DESCRIPTION
Add error handling to url_create_account https://github.com/near/near-workspaces-rs/issues/353
Response from url_create_account method return next error: A top-level account ID AccountId("dev-20240701184705-27025377514474") can't be created by AccountId("testnet"), short top-level account IDs can only be created by AccountId("registrar")