### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.10.1...near-workspaces-v0.11.0) - 2024-07-05
+
+### Other
+- Upgraded deps ([#363](https://github.com/near/near-workspaces-rs/pull/363))
+
 ## [0.10.1](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.10.0...near-workspaces-v0.10.1) - 2024-06-26
 
 ### Added

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `near-workspaces`: 0.10.1 -> 0.11.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.10.1...near-workspaces-v0.11.0) - 2024-07-05

### Other
- Upgraded deps ([#363](https://github.com/near/near-workspaces-rs/pull/363))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).