### PR TITLE
feat: Cacheing the nonce in case of transact_async

### DIFF
--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-retry = "0.3"
 tracing = "0.1"
 url = { version = "2.2.2", features = ["serde"] }
+once_cell = "1.19.0"
 
 near-abi-client = "0.1.1"
 near-gas = { version = "0.2.5", features = ["serde", "borsh", "schemars"] }

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -29,7 +29,6 @@ tokio = { version = "1", features = ["full"] }
 tokio-retry = "0.3"
 tracing = "0.1"
 url = { version = "2.2.2", features = ["serde"] }
-once_cell = "1.19.0"
 
 near-abi-client = "0.1.1"
 near-gas = { version = "0.2.5", features = ["serde", "borsh", "schemars"] }

--- a/workspaces/tests/nonce_cache.rs
+++ b/workspaces/tests/nonce_cache.rs
@@ -16,10 +16,10 @@ async fn test_nonce_caching_parallel() -> anyhow::Result<()> {
 
     // Prepare a large number of transactions to test caching
     const NUM_TRANSACTIONS: usize = 50;
-    let messages: Vec<String> = (0..NUM_TRANSACTIONS).map(|i| format!("msg{}", i)).collect();
 
     // Send transactions in parallel
-    let parallel_tasks = messages.into_iter().map(|msg| {
+    let parallel_tasks = (0..NUM_TRANSACTIONS).map(|i| {
+        let msg = format!("msg{}", i);
         let account = account.clone();
         let contract_id = contract.id().clone();
         tokio::spawn(async move {
@@ -34,6 +34,7 @@ async fn test_nonce_caching_parallel() -> anyhow::Result<()> {
     // Collect all transaction statuses
     let statuses = futures::future::join_all(parallel_tasks).await;
 
+    // Wait for all transactions to complete
     for status in statuses {
         let status = status??;
         loop {

--- a/workspaces/tests/nonce_cache.rs
+++ b/workspaces/tests/nonce_cache.rs
@@ -15,7 +15,7 @@ async fn test_nonce_caching_parallel() -> anyhow::Result<()> {
         .nonce;
 
     // Prepare a large number of transactions to test caching
-    const NUM_TRANSACTIONS: usize = 50;
+    const NUM_TRANSACTIONS: usize = 20;
 
     // Send transactions in parallel
     let parallel_tasks = (0..NUM_TRANSACTIONS).map(|i| {

--- a/workspaces/tests/nonce_cache.rs
+++ b/workspaces/tests/nonce_cache.rs
@@ -1,0 +1,83 @@
+use serde_json::json;
+
+const STATUS_MSG_CONTRACT: &[u8] = include_bytes!("../../examples/res/status_message.wasm");
+
+#[tokio::test]
+async fn test_nonce_caching_parallel() -> anyhow::Result<()> {
+    let worker = near_workspaces::sandbox().await?;
+    let contract = worker.dev_deploy(STATUS_MSG_CONTRACT).await?;
+    let account = worker.dev_create_account().await?;
+
+    // Get the initial nonce
+    let initial_nonce = worker
+        .view_access_key(account.id(), &account.secret_key().public_key())
+        .await?
+        .nonce;
+
+    // Prepare a large number of transactions to test caching
+    const NUM_TRANSACTIONS: usize = 50;
+    let messages: Vec<String> = (0..NUM_TRANSACTIONS).map(|i| format!("msg{}", i)).collect();
+
+    // Send transactions in parallel
+    let parallel_tasks = messages.into_iter().map(|msg| {
+        let account = account.clone();
+        let contract_id = contract.id().clone();
+        tokio::spawn(async move {
+            account
+                .call(&contract_id, "set_status")
+                .args_json(json!({ "message": msg }))
+                .transact_async()
+                .await
+        })
+    });
+
+    // Collect all transaction statuses
+    let statuses = futures::future::join_all(parallel_tasks).await;
+
+    for status in statuses {
+        let status = status??;
+        loop {
+            match status.status().await? {
+                std::task::Poll::Ready(outcome) => {
+                    if outcome.is_success() {
+                        break;
+                    } else {
+                        return Err(anyhow::anyhow!("Transaction failed: {:?}", outcome));
+                    }
+                }
+                std::task::Poll::Pending => {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+            }
+        }
+    }
+
+    // Get the final nonce
+    let final_nonce = worker
+        .view_access_key(account.id(), &account.secret_key().public_key())
+        .await?
+        .nonce;
+
+    // Verify that the nonce increased by exactly the number of transactions
+    assert_eq!(
+        final_nonce - initial_nonce,
+        NUM_TRANSACTIONS as u64,
+        "Nonce did not increment correctly"
+    );
+
+    // Verify the final message
+    let final_msg = account
+        .call(contract.id(), "get_status")
+        .args_json(json!({ "account_id": account.id() }))
+        .view()
+        .await?
+        .json::<String>()?;
+
+    assert_eq!(
+        final_msg,
+        format!("msg{}", NUM_TRANSACTIONS - 1),
+        "Final message does not match expected value"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
- Creating a nonce cache for async transaction. 
- The nonce is stored locally and incremented only sequentially. 

Note: The PR might be a little rough around the edges in terms of best practices and thread safety. Hence, your feedback is welcome. 