### PR TITLE
chore: upgraded near deps to 0.24

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 anyhow = "1.0"
 maplit = "1.0"
 near-units = "0.2.0"
-near-gas = { version = "0.2.5", features = ["serde", "borsh", "schemars"] }
-near-jsonrpc-primitives = "0.23.0"
-near-primitives = "0.23.0"
+near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
+near-jsonrpc-primitives = "0.24"
+near-primitives = "0.24"
 serde = "1.0"
 serde_with = "3.4"
 serde_json = { version = "1.0" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+[toolchain]
+# This specifies the version of Rust we use to build.
+# Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
+# The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
+channel = "1.80"
+components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -14,7 +14,8 @@ async-trait = "0.1"
 base64 = "0.22"
 bs58 = "0.5"
 cargo_metadata = { version = "0.18", optional = true }
-cargo-near = { version = "0.6.3", default-features = false }
+# For cargo-near release
+cargo-near = { version = "0.8", default-features = false }
 chrono = "0.4.19"
 fs2 = "0.4"
 rand = "0.8.4"
@@ -31,19 +32,19 @@ tracing = "0.1"
 url = { version = "2.2.2", features = ["serde"] }
 
 near-abi-client = "0.1.1"
-near-gas = { version = "0.2.5", features = ["serde", "borsh", "schemars"] }
-near-token = { version = "0.2.0", features = ["serde"] }
-near-sdk = { version = "5.2.0", optional = true }
+near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
+near-token = { version = "0.3", features = ["serde"] }
+near-sdk = { version = "5.3", optional = true }
 near-account-id = "1.0.0"
-near-crypto = "0.23.0"
-near-primitives = "0.23.0"
-near-jsonrpc-primitives = "0.23.0"
-near-jsonrpc-client = { version = "0.10.1", features = ["sandbox"] }
+near-crypto = "0.24"
+near-primitives = "0.24"
+near-jsonrpc-primitives = "0.24"
+near-jsonrpc-client = { version = "0.11", features = ["sandbox"] }
 near-sandbox-utils = "0.9.0"
-near-chain-configs = { version = "0.23.0", optional = true }
+near-chain-configs = { version = "0.24", optional = true }
 
 [build-dependencies]
-near-sandbox-utils = "0.8.0"
+near-sandbox-utils = "0.9.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -51,7 +52,7 @@ libc = "0.2"
 [dev-dependencies]
 anyhow = "1.0"
 futures = "0.3"
-near-sdk = "5.2.0"
+near-sdk = "5.3"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -17,6 +17,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 pub use near_account_id::AccountId;
+use near_crypto::Signer;
 use near_primitives::borsh::{BorshDeserialize, BorshSerialize};
 
 use serde::{Deserialize, Serialize};
@@ -292,11 +293,11 @@ impl InMemorySigner {
         ))
     }
 
-    pub(crate) fn inner(&self) -> near_crypto::InMemorySigner {
-        near_crypto::InMemorySigner::from_secret_key(
+    pub(crate) fn inner(&self) -> Signer {
+        Signer::InMemory(near_crypto::InMemorySigner::from_secret_key(
             self.account_id.clone(),
             self.secret_key.0.clone(),
-        )
+        ))
     }
 }
 

--- a/workspaces/tests/test-contracts/status-message/Cargo.toml
+++ b/workspaces/tests/test-contracts/status-message/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "5.0.0-alpha.2"
+near-sdk = "5.3.0"
 
 [profile.release]
 codegen-units = 1

--- a/workspaces/tests/test-contracts/type-serialize/Cargo.toml
+++ b/workspaces/tests/test-contracts/type-serialize/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bs58 = "0.5"
-near-sdk = "5.0.0-alpha.2"
+near-sdk = "5.3.0"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
In the PR, I have made the next assumption that we don't need reproducible builds (e.g. docker support) for near-workspaces as mostly it's a library for testing purposes rather than production usage.

@race-of-sloths