### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.11.1...near-workspaces-v0.12.0) - 2024-08-15
+
+### Other
+- [**breaking**] upgraded near deps to 0.24 ([#370](https://github.com/near/near-workspaces-rs/pull/370))
+
 ## [0.11.1](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.11.0...near-workspaces-v0.11.1) - 2024-08-07
 
 ### Fixed

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `near-workspaces`: 0.11.1 -> 0.12.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.11.1...near-workspaces-v0.12.0) - 2024-08-15

### Other
- [**breaking**] upgraded near deps to 0.24 ([#370](https://github.com/near/near-workspaces-rs/pull/370))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).