### PR TITLE
chore!: updates near-* dependencies to 0.25

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,8 +9,8 @@ anyhow = "1.0"
 maplit = "1.0"
 near-units = "0.2.0"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
-near-jsonrpc-primitives = "0.24"
-near-primitives = "0.24"
+near-jsonrpc-primitives = "0.25"
+near-primitives = "0.25"
 serde = "1.0"
 serde_with = "3.4"
 serde_json = { version = "1.0" }

--- a/examples/noop-contract/Cargo.toml
+++ b/examples/noop-contract/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "5.0.0-alpha.2"
+near-sdk = "5.4.0"
 
 [profile.release]
 codegen-units = 1

--- a/examples/simple-contract/Cargo.toml
+++ b/examples/simple-contract/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "5.0.0-alpha.2"
+near-sdk = "5.4.0"
 
 [profile.release]
 codegen-units = 1

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -33,7 +33,7 @@ url = { version = "2.2.2", features = ["serde"] }
 near-abi-client = "0.1.1"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
 near-token = { version = "0.3", features = ["serde"] }
-near-sdk = { version = "5.3", optional = true }
+near-sdk = { version = "5.4", optional = true }
 near-account-id = "1.0.0"
 near-crypto = "0.25"
 near-primitives = "0.25"
@@ -51,7 +51,7 @@ libc = "0.2"
 [dev-dependencies]
 anyhow = "1.0"
 futures = "0.3"
-near-sdk = "5.3"
+near-sdk = "5.4"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -35,15 +35,15 @@ near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
 near-token = { version = "0.3", features = ["serde"] }
 near-sdk = { version = "5.3", optional = true }
 near-account-id = "1.0.0"
-near-crypto = "0.24"
-near-primitives = "0.24"
-near-jsonrpc-primitives = "0.24"
-near-jsonrpc-client = { version = "0.11", features = ["sandbox"] }
-near-sandbox-utils = "0.10"
-near-chain-configs = { version = "0.24", optional = true }
+near-crypto = "0.25"
+near-primitives = "0.25"
+near-jsonrpc-primitives = "0.25"
+near-jsonrpc-client = { version = "0.12", features = ["sandbox"] }
+near-sandbox-utils = "0.11"
+near-chain-configs = { version = "0.25", optional = true }
 
 [build-dependencies]
-near-sandbox-utils = "0.10"
+near-sandbox-utils = "0.11"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -39,11 +39,11 @@ near-crypto = "0.25"
 near-primitives = "0.25"
 near-jsonrpc-primitives = "0.25"
 near-jsonrpc-client = { version = "0.12", features = ["sandbox"] }
-near-sandbox-utils = "0.11"
+near-sandbox-utils = "0.10"
 near-chain-configs = { version = "0.25", optional = true }
 
 [build-dependencies]
-near-sandbox-utils = "0.11"
+near-sandbox-utils = "0.10"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/workspaces/tests/test-contracts/status-message/Cargo.toml
+++ b/workspaces/tests/test-contracts/status-message/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "5.3.0"
+near-sdk = "5.4.0"
 
 [profile.release]
 codegen-units = 1

--- a/workspaces/tests/test-contracts/type-serialize/Cargo.toml
+++ b/workspaces/tests/test-contracts/type-serialize/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bs58 = "0.5"
-near-sdk = "5.3.0"
+near-sdk = "5.4.0"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
Sandbox has not been updated as it's broken on Mac OS.
See https://github.com/near/nearcore/issues/12062