### PR TITLE
chore: release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [0.14.1](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.14.0...near-workspaces-v0.14.1) - 2024-10-18
+
+### Fixed
+
+- TransactionStatus::status should not be waiting for Final ([#379](https://github.com/near/near-workspaces-rs/pull/379))
+
+### Other
+
+- fix clippy 1.82 (doc preambles) ([#381](https://github.com/near/near-workspaces-rs/pull/381))
+- bump cargo-near-build to 0.2.0 ([#380](https://github.com/near/near-workspaces-rs/pull/380))
+
 ## [0.14.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.13.0...near-workspaces-v0.14.0) - 2024-09-12
 
 ### Other

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `near-workspaces`: 0.14.0 -> 0.14.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.1](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.14.0...near-workspaces-v0.14.1) - 2024-10-18

### Fixed

- TransactionStatus::status should not be waiting for Final ([#379](https://github.com/near/near-workspaces-rs/pull/379))

### Other

- fix clippy 1.82 (doc preambles) ([#381](https://github.com/near/near-workspaces-rs/pull/381))
- bump cargo-near-build to 0.2.0 ([#380](https://github.com/near/near-workspaces-rs/pull/380))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).