### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.14.1...near-workspaces-v0.15.0) - 2024-11-18
+
+### Other
+
+- [**breaking**] updates near-* dependencies to 0.27 release ([#387](https://github.com/near/near-workspaces-rs/pull/387))
+- [**breaking**] reexport `cargo-near-build` for configurable build if needed ([#386](https://github.com/near/near-workspaces-rs/pull/386))
+- make cargo-near-build optional in manifest ([#383](https://github.com/near/near-workspaces-rs/pull/383))
+
 ## [0.14.1](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.14.0...near-workspaces-v0.14.1) - 2024-10-18
 
 ### Fixed

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `near-workspaces`: 0.14.1 -> 0.15.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.14.1...near-workspaces-v0.15.0) - 2024-11-18

### Other

- [**breaking**] updates near-* dependencies to 0.27 release ([#387](https://github.com/near/near-workspaces-rs/pull/387))
- [**breaking**] reexport `cargo-near-build` for configurable build if needed ([#386](https://github.com/near/near-workspaces-rs/pull/386))
- make cargo-near-build optional in manifest ([#383](https://github.com/near/near-workspaces-rs/pull/383))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).