### PR TITLE
chore!: reexport `cargo-near-build` for configurable build if needed

### DIFF
--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -13,7 +13,7 @@ Library for automating workflows and testing NEAR smart contracts.
 async-trait = "0.1"
 base64 = "0.22"
 bs58 = "0.5"
-cargo-near-build = { version = "0.2.0", optional = true }
+cargo-near-build = { version = "0.3.0", optional = true }
 chrono = "0.4.19"
 fs2 = "0.4"
 rand = "0.8.4"

--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -10,6 +10,8 @@
 mod cargo;
 #[cfg(feature = "unstable")]
 pub use cargo::compile_project;
+#[cfg(feature = "unstable")]
+pub use cargo_near_build;
 
 mod worker;
 


### PR DESCRIPTION
PR addresses this TODO https://github.com/near/near-sdk-rs/pull/1253#discussion_r1833629296 , which later ~will be~ has been removed from `near-sdk` code, for cases:
1. when non-async function is required in `static std::sync::OnceLock<T>/LazyLock<T, F>` creation like here https://github.com/dj8yfo/near-sdk-rs/blob/7be211e1b2991f6c5b4db78972784dac2f066e32/examples/fungible-token/tests/workspaces.rs#L47
2. when non-default build is required like with `no-abi` here https://github.com/dj8yfo/abstract-dao/blob/fe9d16797bf582f0ea24380c1e4ad6bdb8c97283/tests/common.rs#L33

PR avoids necessity to import `cargo-near-build` separately as a dependency

PR should best be published with a major release, to avoid weird breakage `0.14.1 -> 0.14.x`

