### PR TITLE
0.27 space rem

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,8 +9,8 @@ anyhow = "1.0"
 maplit = "1.0"
 near-units = "0.2.0"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
-near-jsonrpc-primitives = "0.26"
-near-primitives = "0.26"
+near-jsonrpc-primitives = "0.27"
+near-primitives = "0.27"
 serde = "1.0"
 serde_with = "3.4"
 serde_json = { version = "1.0" }

--- a/examples/noop-contract/Cargo.toml
+++ b/examples/noop-contract/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "5.5.0"
+near-sdk = "5.6.0"
 
 [profile.release]
 codegen-units = 1

--- a/examples/simple-contract/Cargo.toml
+++ b/examples/simple-contract/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "5.5.0"
+near-sdk = "5.6.0"
 
 [profile.release]
 codegen-units = 1

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -38,11 +38,11 @@ near-crypto = "0.27"
 near-primitives = "0.27"
 near-jsonrpc-primitives = "0.27"
 near-jsonrpc-client = { version = "0.14", features = ["sandbox"] }
-near-sandbox-utils = "0.11"
+near-sandbox-utils = "0.12"
 near-chain-configs = { version = "0.27", optional = true }
 
 [build-dependencies]
-near-sandbox-utils = "0.10"
+near-sandbox-utils = "0.12"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -13,7 +13,7 @@ Library for automating workflows and testing NEAR smart contracts.
 async-trait = "0.1"
 base64 = "0.22"
 bs58 = "0.5"
-cargo-near-build = { version = "0.2.0", optional = true }
+cargo-near-build = { version = "0.3.0", optional = true }
 chrono = "0.4.19"
 fs2 = "0.4"
 rand = "0.8.4"
@@ -32,14 +32,14 @@ url = { version = "2.2.2", features = ["serde"] }
 near-abi-client = "0.1.1"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
 near-token = { version = "0.3", features = ["serde"] }
-near-sdk = { version = "5.5", optional = true }
+near-sdk = { version = "5.6", optional = true }
 near-account-id = "1.0.0"
-near-crypto = "0.26"
-near-primitives = "0.26"
-near-jsonrpc-primitives = "0.26"
-near-jsonrpc-client = { version = "0.13", features = ["sandbox"] }
-near-sandbox-utils = "0.10"
-near-chain-configs = { version = "0.26", optional = true }
+near-crypto = "0.27"
+near-primitives = "0.27"
+near-jsonrpc-primitives = "0.27"
+near-jsonrpc-client = { version = "0.14", features = ["sandbox"] }
+near-sandbox-utils = "0.11"
+near-chain-configs = { version = "0.27", optional = true }
 
 [build-dependencies]
 near-sandbox-utils = "0.10"
@@ -50,13 +50,13 @@ libc = "0.2"
 [dev-dependencies]
 anyhow = "1.0"
 futures = "0.3"
-near-sdk = "5.5"
+near-sdk = "5.6"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 
 [features]
 default = ["install"]
-install = []                                              # Install the sandbox binary during compile time
+install = []                          # Install the sandbox binary during compile time
 interop_sdk = ["near-sdk"]
 unstable = ["dep:cargo-near-build"]
 experimental = ["near-chain-configs"]

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -13,8 +13,7 @@ Library for automating workflows and testing NEAR smart contracts.
 async-trait = "0.1"
 base64 = "0.22"
 bs58 = "0.5"
-cargo_metadata = { version = "0.18", optional = true }
-cargo-near-build = { version = "0.2.0" }
+cargo-near-build = { version = "0.2.0", optional = true }
 chrono = "0.4.19"
 fs2 = "0.4"
 rand = "0.8.4"
@@ -57,9 +56,9 @@ tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 
 [features]
 default = ["install"]
-install = []                          # Install the sandbox binary during compile time
+install = []                                              # Install the sandbox binary during compile time
 interop_sdk = ["near-sdk"]
-unstable = ["cargo_metadata"]
+unstable = ["dep:cargo-near-build"]
 experimental = ["near-chain-configs"]
 
 [package.metadata.docs.rs]

--- a/workspaces/tests/test-contracts/status-message/Cargo.toml
+++ b/workspaces/tests/test-contracts/status-message/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "5.5.0"
+near-sdk = "5.6.0"
 
 [profile.release]
 codegen-units = 1

--- a/workspaces/tests/test-contracts/type-serialize/Cargo.toml
+++ b/workspaces/tests/test-contracts/type-serialize/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bs58 = "0.5"
-near-sdk = "5.5.0"
+near-sdk = "5.6.0"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
- **chore!: updates near-* dependencies to 0.27 release**
- **updated sandbox version**
- **updated examples contracts**
- **ci: add jlumbroso/free-disk-space to ./github/workflows/test.yml**
