### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.16.0...near-workspaces-v0.17.0) - 2024-12-26
+
+### Added
+
+- [**breaking**] `worker.dev_create_account`, `worker.dev_deploy` create subaccounts of root account instead of tla (sandbox, testnet) (#369)
+
 ## [0.16.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.15.0...near-workspaces-v0.16.0) - 2024-12-18
 
 ### Fixed

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `near-workspaces`: 0.16.0 -> 0.17.0 (⚠️ API breaking changes)

### ⚠️ `near-workspaces` breaking changes

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/inherent_method_missing.ron

Failed in:
  Worker::dev_generate, previously in file /tmp/.tmp1p4bcu/near-workspaces/src/network/variants.rs:75

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait near_workspaces::DevNetwork gained RootAccountSubaccountCreator in file /tmp/.tmpwlIIQu/near-workspaces-rs/workspaces/src/network/variants.rs:215

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/trait_missing.ron

Failed in:
  trait near_workspaces::network::AllowDevAccountCreation, previously in file /tmp/.tmp1p4bcu/near-workspaces/src/network/variants.rs:38

--- failure trait_removed_supertrait: supertrait removed or renamed ---

Description:
A supertrait was removed from a trait. Users of the trait can no longer assume it can also be used like its supertrait.
        ref: https://doc.rust-lang.org/reference/items/traits.html#supertraits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/trait_removed_supertrait.ron

Failed in:
  supertrait near_workspaces::network::TopLevelAccountCreator of trait DevNetwork in file /tmp/.tmpwlIIQu/near-workspaces-rs/workspaces/src/network/variants.rs:215
  supertrait near_workspaces::prelude::TopLevelAccountCreator of trait DevNetwork in file /tmp/.tmpwlIIQu/near-workspaces-rs/workspaces/src/network/variants.rs:215
  supertrait near_workspaces::network::AllowDevAccountCreation of trait DevNetwork in file /tmp/.tmpwlIIQu/near-workspaces-rs/workspaces/src/network/variants.rs:215
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.17.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.16.0...near-workspaces-v0.17.0) - 2024-12-26

### Added

- [**breaking**] `worker.dev_create_account`, `worker.dev_deploy` create subaccounts of root account instead of tla (sandbox, testnet) (#369)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).