### PR TITLE
ci: fix new compile warn and clippy of 1.84

### DIFF
--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -52,8 +52,8 @@ impl Sandbox {
         }
     }
 
-    pub(crate) async fn from_builder_with_version<'a>(
-        build: NetworkBuilder<'a, Self>,
+    pub(crate) async fn from_builder_with_version(
+        build: NetworkBuilder<'_, Self>,
         version: &str,
     ) -> Result<Self> {
         // Check the conditions of the provided rpc_url and validator_key

--- a/workspaces/src/network/server.rs
+++ b/workspaces/src/network/server.rs
@@ -171,7 +171,7 @@ impl SandboxServer {
     /// the sandbox node.
     pub(crate) fn unlock_lockfiles(&mut self) -> Result<()> {
         if let Some(rpc_port_lock) = self.rpc_port_lock.take() {
-            rpc_port_lock.unlock().map_err(|e| {
+            <std::fs::File as FileExt>::unlock(&rpc_port_lock).map_err(|e| {
                 ErrorKind::Io.full(
                     format!(
                         "failed to unlock lockfile for rpc_port={:?}",
@@ -182,7 +182,7 @@ impl SandboxServer {
             })?;
         }
         if let Some(net_port_lock) = self.net_port_lock.take() {
-            net_port_lock.unlock().map_err(|e| {
+            <std::fs::File as FileExt>::unlock(&net_port_lock).map_err(|e| {
                 ErrorKind::Io.full(
                     format!("failed to unlock lockfile for net_port={:?}", self.net_port),
                     e,

--- a/workspaces/src/worker/mod.rs
+++ b/workspaces/src/worker/mod.rs
@@ -54,7 +54,7 @@ pub fn sandbox<'a>() -> NetworkBuilder<'a, Sandbox> {
 }
 
 /// Spin up a new sandbox instance, and grab a [`Worker`] that interacts with it.
-pub async fn sandbox_with_version<'a>(version: &str) -> Result<Worker<Sandbox>> {
+pub async fn sandbox_with_version(version: &str) -> Result<Worker<Sandbox>> {
     let network_builder = NetworkBuilder::new("sandbox");
     let network = Sandbox::from_builder_with_version(network_builder, version).await?;
     Ok(Worker::new(network))


### PR DESCRIPTION
looks like this was a new lint from https://github.com/rust-lang/rust/issues/48919 , 
and the lint was correct about `fs2::FileExt` vs

```rust
    #[unstable(feature = "file_lock", issue = "130994")]
    pub fn unlock(&self) -> io::Result<()> {
        self.inner.unlock()
    }

```