### PR TITLE
ci: remove clippy::nursery

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Run clippy
-      run: cargo clippy --all-targets -- -D clippy::all -D clippy::nursery
+      run: cargo clippy --all-targets -- -D clippy::all
 
   cargo-fmt:
     runs-on: ubuntu-20.04

--- a/workspaces/tests/query.rs
+++ b/workspaces/tests/query.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::literal_string_with_formatting_args)]
 use near_workspaces::types::NearToken;
 use near_workspaces::{network::Sandbox, Contract, Worker};
 


### PR DESCRIPTION
resolves #404 

As https://github.com/rust-lang/rust-clippy/issues/14363#issuecomment-2704478896 pointed out it makes little sense to test fresh/new/somewhat-unstable lints with `near-workspaces-rs`'s ci