### PR TITLE
feat: replace cargo-near-build with patch from feat/build-external-method branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,28 +54,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Free Disk Space (Ubuntu)
-      if: matrix.platform == 'ubuntu-latest' 
-      uses: jlumbroso/free-disk-space@v1.3.1
-      with:
-        # this might remove tools that are actually needed,
-        # if set to "true" but frees about 6 GB
-        tool-cache: false
-        
-        # all of these default to true, but feel free to set to
-        # "false" if necessary for your workflow
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: true
-        docker-images: true
-        swap-storage: true
     - name: "${{ matrix.toolchain }}"
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: ${{ matrix.toolchain }}
         default: true
+    - name: Install cargo-near CLI (dependency for examples' build)
+      run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.14.0/cargo-near-installer.sh | sh
     - uses: Swatinem/rust-cache@v2
     - name: Add wasm32 target
       run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -25,7 +25,7 @@ jobs:
       run: cargo clippy --all-targets -- -D clippy::all
 
   cargo-fmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
   # won't look as expected, when rendered, and sometimes errors, which will prevent doc from being
   # generated at release time altogether.
   cargo-doc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -13,7 +13,7 @@ Library for automating workflows and testing NEAR smart contracts.
 async-trait = "0.1"
 base64 = "0.22"
 bs58 = "0.5"
-cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/build-external-method", optional = true }
+cargo-near-build = { version = "0.6.0", optional = true }
 chrono = "0.4.19"
 fs2 = "0.4"
 rand = "0.8.4"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -13,7 +13,7 @@ Library for automating workflows and testing NEAR smart contracts.
 async-trait = "0.1"
 base64 = "0.22"
 bs58 = "0.5"
-cargo-near-build = { version = "0.4.1", optional = true }
+cargo-near-build = { version = "0.5.1", git = "https://github.com/dj8yfo/cargo-near.git", branch = "feat/build-external-method", optional = true }
 chrono = "0.4.19"
 fs2 = "0.4"
 rand = "0.8.4"

--- a/workspaces/src/cargo/mod.rs
+++ b/workspaces/src/cargo/mod.rs
@@ -30,10 +30,9 @@ pub async fn compile_project(project_path: &str) -> crate::Result<Vec<u8>> {
     };
 
     let compile_artifact =
-        cargo_near_build::build(cargo_opts).map_err(|e| ErrorKind::Io.custom(e))?;
+        cargo_near_build::build_with_cli(cargo_opts).map_err(|e| ErrorKind::Io.custom(e))?;
 
     let file = compile_artifact
-        .path
         .canonicalize()
         .map_err(|e| ErrorKind::Io.custom(e))?;
     tokio::fs::read(file)


### PR DESCRIPTION
this depends on https://github.com/near/cargo-near/pull/333

additionally this has been tested in scope of https://github.com/near/near-sdk-rs/pull/1350