### PR TITLE
chore: release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.19.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.18.0...near-workspaces-v0.19.0) - 2025-05-05
+
+### Added
+
+- [**breaking**] build with external `cargo-near` binary CLI in `near_workspaces::compile_project` ([#411](https://github.com/near/near-workspaces-rs/pull/411))
+
 ## [0.18.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.17.0...near-workspaces-v0.18.0) - 2025-03-14
 
 ### Other

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `near-workspaces`: 0.18.0 -> 0.19.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.19.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.18.0...near-workspaces-v0.19.0) - 2025-05-05

### Added

- [**breaking**] build with external `cargo-near` binary CLI in `near_workspaces::compile_project` ([#411](https://github.com/near/near-workspaces-rs/pull/411))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).