### PR TITLE
chore: release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.20.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.19.0...near-workspaces-v0.20.0) - 2025-05-14
+
+### Other
+
+- [**breaking**] updates near-* dependencies to 0.30 release ([#413](https://github.com/near/near-workspaces-rs/pull/413))
+
 ## [0.19.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.18.0...near-workspaces-v0.19.0) - 2025-05-05
 
 ### Added

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `near-workspaces`: 0.19.0 -> 0.20.0 (⚠ API breaking changes)

### ⚠ `near-workspaces` breaking changes

```text
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field code_hash of struct AccountDetailsPatch, previously in file /tmp/.tmpscwjix/near-workspaces/src/types/account.rs:337
  field code_hash of struct AccountDetailsPatch, previously in file /tmp/.tmpscwjix/near-workspaces/src/types/account.rs:337
  field code_hash of struct AccountDetails, previously in file /tmp/.tmpscwjix/near-workspaces/src/types/account.rs:401

--- failure type_method_marked_deprecated: type method #[deprecated] added ---

Description:
A type method is now #[deprecated]. Downstream crates will get a compiler warning when using this method.
        ref: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/type_method_marked_deprecated.ron

Failed in:
  method near_workspaces::types::AccountDetailsPatch::code_hash in /tmp/.tmplRfgU8/near-workspaces-rs/workspaces/src/types/account.rs:373
  method near_workspaces::AccountDetailsPatch::code_hash in /tmp/.tmplRfgU8/near-workspaces-rs/workspaces/src/types/account.rs:373
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.20.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.19.0...near-workspaces-v0.20.0) - 2025-05-14

### Other

- [**breaking**] updates near-* dependencies to 0.30 release ([#413](https://github.com/near/near-workspaces-rs/pull/413))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).