### PR TITLE
chore: release v0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.20.1](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.20.0...near-workspaces-v0.20.1) - 2025-05-15
+
+### Added
+
+- use long random account id or account id prefix as secret key seed ([#416](https://github.com/near/near-workspaces-rs/pull/416))
+
 ## [0.20.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.19.0...near-workspaces-v0.20.0) - 2025-05-14
 
 ### Other

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `near-workspaces`: 0.20.0 -> 0.20.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.20.1](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.20.0...near-workspaces-v0.20.1) - 2025-05-15

### Added

- use long random account id or account id prefix as secret key seed ([#416](https://github.com/near/near-workspaces-rs/pull/416))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).