### PR TITLE
chore: release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.20.2](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.20.1...near-workspaces-v0.20.2) - 2025-08-15
+
+### Other
+
+- update near-* dependencies to 0.31 ([#423](https://github.com/near/near-workspaces-rs/pull/423))
+- revert back to stable; install second toolchain for 1 test ([#419](https://github.com/near/near-workspaces-rs/pull/419))
+# Changelog
+
 ## [Unreleased]
 
 ## [0.20.1](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.20.0...near-workspaces-v0.20.1) - 2025-05-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.20.2](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.20.1...near-workspaces-v0.20.2) - 2025-08-15
+## [0.21.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.20.1...near-workspaces-v0.21.0) - 2025-08-15
 
 ### Other
 
 - update near-* dependencies to 0.31 ([#423](https://github.com/near/near-workspaces-rs/pull/423))
 - revert back to stable; install second toolchain for 1 test ([#419](https://github.com/near/near-workspaces-rs/pull/419))
-# Changelog
-
-## [Unreleased]
 
 ## [0.20.1](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.20.0...near-workspaces-v0.20.1) - 2025-05-15
 

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.20.1"
+version = "0.20.2"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.20.2"
+version = "0.21.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION


## 🤖 New release

* `near-workspaces`: 0.20.1 -> 0.21.0

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).