### PR TITLE
chore: release v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.1](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.23.0...near-workspaces-v0.23.1) - 2026-07-15
+
+### Other
+
+- retire RC sandbox pin, use default sandbox() ([#454](https://github.com/near/near-workspaces-rs/pull/454))
+
 ## [0.23.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.22.4...near-workspaces-v0.23.0) - 2026-07-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.1](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.23.0...near-workspaces-v0.23.1) - 2026-08-10
+
+### Other
+
+- retire RC sandbox pin, use default sandbox() ([#454](https://github.com/near/near-workspaces-rs/pull/454))
+
 ## [0.23.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.22.4...near-workspaces-v0.23.0) - 2026-07-09
 
 ### Added

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.23.0"
+version = "0.23.1"
 edition.workspace = true
 rust-version.workspace = true
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-workspaces`: 0.23.0 -> 0.23.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.23.1](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.23.0...near-workspaces-v0.23.1) - 2026-08-10

### Other

- retire RC sandbox pin, use default sandbox() ([#454](https://github.com/near/near-workspaces-rs/pull/454))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).